### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/ssatisha/a28a6aca-c7d7-4d26-89c1-85040be8a950/43595ea7-163a-4022-be6d-60dc8f0f5b48/_apis/work/boardbadge/aee63520-05a3-45b8-a2b5-7c086fa6292a)](https://dev.azure.com/ssatisha/a28a6aca-c7d7-4d26-89c1-85040be8a950/_boards/board/t/43595ea7-163a-4022-be6d-60dc8f0f5b48/Microsoft.RequirementCategory)
 # JacocoMaven


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/ssatisha/a28a6aca-c7d7-4d26-89c1-85040be8a950/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.